### PR TITLE
Implement retreat action and fix turn progression

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -406,12 +406,14 @@ export class Game {
      * ペンディングアクション処理
      */
     async _handlePendingAction(dataset) {
-        const { cardId, zone } = dataset;
-        
+        const { cardId, zone, index } = dataset;
+
         if (this.state.pendingAction.type === 'attach-energy' && (zone === 'active' || zone === 'bench')) {
             if (cardId) {
                 await this._attachEnergy(this.state.pendingAction.sourceCardId, cardId);
             }
+        } else if (this.state.pendingAction.type === 'retreat-promote' && zone === 'bench') {
+            await this._performRetreat(parseInt(index, 10));
         }
     }
 
@@ -433,6 +435,28 @@ export class Game {
             newState.prompt.message = 'あなたのターンです。アクションを選択してください。';
         }
         
+        this._clearAllHighlights();
+        this._updateState(newState);
+    }
+
+    /**
+     * にげる実行
+     */
+    async _performRetreat(benchIndex) {
+        const active = this.state.players.player.active;
+        if (!active) return;
+
+        let newState = this.turnManager.handlePlayerMainPhase(this.state, 'retreat_pokemon', {
+            fromActiveId: active.id,
+            toBenchIndex: benchIndex
+        });
+
+        if (newState !== this.state) {
+            feedbackSystem.success('にげました');
+            newState.pendingAction = null;
+            newState.prompt.message = 'あなたのターンです。アクションを選択してください。';
+        }
+
         this._clearAllHighlights();
         this._updateState(newState);
     }
@@ -482,6 +506,12 @@ export class Game {
         // 攻撃実行
         newState = await this.turnManager.executeAttack(newState);
         this._updateState(newState);
+
+        if (newState.turnPlayer === 'cpu') {
+            setTimeout(async () => {
+                await this._executeCpuTurn();
+            }, 1000);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add missing `retreat` logic to pay energy cost, swap active with bench, and discard energy
- Handle pending retreat actions and trigger CPU turn after player attacks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ddc2315c832b91aff3b24d0f90e5