### PR TITLE
Improve animation reliability

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -23,8 +23,11 @@ export class AnimationManager {
         playCard: 500,
         attack: 800,
         damage: 600,
+        hpDamage: 600,
         knockout: 1200,
-        energyAttach: 700
+        energyAttach: 700,
+        slideInBottom: 500,
+        fadeIn: 300
       }
     };
     
@@ -186,14 +189,14 @@ export class AnimationManager {
   async animateAttack(attackerElement, defenderElement) {
     const attackerPromise = new Promise(resolve => {
       this.addAnimationClass(attackerElement, 'animate-attack');
-      this.waitForAnimation(attackerElement, 'attackForward', resolve);
+      this.waitForAnimation(attackerElement, 'attack', resolve);
     });
     
     // 少し遅れてダメージアニメーション
     const defenderPromise = new Promise(resolve => {
       setTimeout(() => {
         this.addAnimationClass(defenderElement, 'animate-damage');
-        this.waitForAnimation(defenderElement, 'damageShake', resolve);
+        this.waitForAnimation(defenderElement, 'damage', resolve);
       }, 300);
     });
     
@@ -207,7 +210,7 @@ export class AnimationManager {
   async animateHPDamage(hpElement) {
     return new Promise(resolve => {
       this.addAnimationClass(hpElement, 'animate-hp-damage');
-      this.waitForAnimation(hpElement, 'hpFlash', resolve);
+      this.waitForAnimation(hpElement, 'hpDamage', resolve);
     });
   }
   
@@ -319,20 +322,25 @@ export class AnimationManager {
    * ゲームメッセージアニメーション
    * @param {Element} messageElement - メッセージ要素
    */
-  animateMessage(messageElement) {
-    this.addAnimationClass(messageElement, 'animate-fade-in');
+  async animateMessage(messageElement) {
+    return new Promise(resolve => {
+      this.addAnimationClass(messageElement, 'animate-fade-in');
+      this.waitForAnimation(messageElement, 'fadeIn', resolve);
+    });
   }
   
   /**
    * エラーメッセージアニメーション
    * @param {Element} messageElement - メッセージ要素
    */
-  animateError(messageElement) {
-    this.addAnimationClass(messageElement, 'error-message');
-    
-    setTimeout(() => {
-      this.removeAnimationClass(messageElement, 'error-message');
-    }, 1000);
+  async animateError(messageElement) {
+    return new Promise(resolve => {
+      this.addAnimationClass(messageElement, 'error-message');
+      this.waitForAnimation(messageElement, 'damage', () => {
+        this.removeAnimationClass(messageElement, 'error-message');
+        resolve();
+      });
+    });
   }
   
   /**

--- a/js/setup-manager.js
+++ b/js/setup-manager.js
@@ -74,18 +74,15 @@ export class SetupManager {
    */
   async shuffleDeckAnimation(deckElement) {
     return new Promise(resolve => {
-      deckElement.classList.add('animate-shuffle');
-      
       // シャッフルエフェクト（3回震わせる）
       let shakeCount = 0;
       const shakeInterval = setInterval(() => {
         deckElement.style.transform = `translateX(${Math.random() * 6 - 3}px) translateY(${Math.random() * 6 - 3}px)`;
         shakeCount++;
-        
+
         if (shakeCount >= 6) {
           clearInterval(shakeInterval);
           deckElement.style.transform = '';
-          deckElement.classList.remove('animate-shuffle');
           resolve();
         }
       }, 100);

--- a/js/turn-manager.js
+++ b/js/turn-manager.js
@@ -237,15 +237,28 @@ export class TurnManager {
     }
 
     const { attackIndex, attacker } = newState.pendingAction;
-    
+    const defender = attacker === 'player' ? 'cpu' : 'player';
+    const defenderElement = attacker === 'player'
+      ? document.querySelector('.opponent-board .active-top')
+      : document.querySelector('.player-self .active-bottom');
+
     // 攻撃実行
     newState = Logic.performAttack(newState, attacker, attackIndex);
-    
+
     // 攻撃アニメーション
     await this.animateAttack(attacker, newState);
 
-    // きぜつチェック
-    const defender = attacker === 'player' ? 'cpu' : 'player';
+    // HPダメージアニメーション
+    if (defenderElement) {
+      const hpTarget = defenderElement.querySelector('.hp') || defenderElement;
+      await animationManager.animateHPDamage(hpTarget);
+    }
+
+    // きぜつチェックとアニメーション
+    const defenderState = newState.players[defender];
+    if (defenderElement && defenderState.active && defenderState.active.damage >= defenderState.active.hp) {
+      await animationManager.animateKnockout(defenderElement);
+    }
     newState = Logic.checkForKnockout(newState, defender);
 
     // ペンディングアクションクリア


### PR DESCRIPTION
## Summary
- Add explicit animation durations and consistent names for smoother animation timing
- Reset message and error animations after playback to ensure repeatability
- Trigger HP damage and knockout animations during attacks and simplify deck shuffling effect

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e918e748832b9c3cd6f73c480ac3