### PR TITLE
Simplify setup flow and remove extra animations

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -22,8 +22,6 @@ export class Game {
         // Selected card for setup
         this.selectedCardForSetup = null;
         
-        // Animation control flags
-        this.setupAnimationsExecuted = false;
     } // End of constructor
 
     _delay(ms) {
@@ -154,14 +152,11 @@ export class Game {
      */
     async _startGameSetup() {
         console.log('🎮 Starting game setup...');
-        this.state = await this.setupManager.initializeGame(this.state);
+        this.state = this.setupManager.initializeGame(this.state);
         
         // 単一のレンダリングサイクルで処理（二重レンダリング防止）
         console.log('🔄 Updating game state and rendering...');
         this._updateState(this.state);
-        
-        // DOM要素の完全な準備を確実に待つ
-        this._scheduleSetupAnimations();
         
         // デバッグ: 手札の内容を確認
         console.log('👤 Player hand after setup:', this.state.players.player.hand.length, 'cards');
@@ -189,7 +184,7 @@ export class Game {
                     this.view._renderHand(playerHandElement, this.state.players.player.hand, 'player');
                 }
             }
-        }, 500); // アニメーション完了を待つ
+        }, 500);
     }
 
     /**
@@ -719,7 +714,7 @@ export class Game {
         this.view.showMessage('セットアップ完了！ゲーム開始です！', 'success');
         
         // 状態を更新して、カードが表面になるようにする
-        let newState = await this.setupManager.confirmSetup(this.state);
+        let newState = this.setupManager.confirmSetup(this.state);
         this._updateState(newState);
 
         // カードをフリップするアニメーション
@@ -755,158 +750,6 @@ export class Game {
         }
         
         console.log('✅ Setup confirmed, game starting!');
-    }
-
-    /**
-     * セットアップアニメーション スケジューリング
-     */
-    _scheduleSetupAnimations() {
-        // 重複実行防止
-        if (this.setupAnimationsExecuted) {
-            console.log('⏭️ Setup animations already executed, skipping');
-            return;
-        }
-        
-        console.log('🎬 Scheduling setup animations...');
-        this.setupAnimationsExecuted = true;
-        
-        // requestAnimationFrame を使って確実にDOM準備完了を待つ
-        requestAnimationFrame(() => {
-            requestAnimationFrame(async () => {
-                // さらに少し待ってから実行
-                setTimeout(async () => {
-                    await this._executeSetupAnimations();
-                }, 100);
-            });
-        });
-    }
-
-    /**
-     * セットアップアニメーション実行
-     */
-    async _executeSetupAnimations() {
-        console.log('🎬 Executing setup animations...');
-        
-        try {
-            // DOM要素の存在確認を強化
-            await this._verifyDOMElements();
-            
-            // 手札のアニメーション
-            await this._animateInitialHandDraw();
-            
-            // サイドカードのアニメーション
-            await this._animatePrizeCardSetup();
-            
-            console.log('✅ Setup animations completed');
-        } catch (error) {
-            console.error('❌ Setup animation error:', error);
-        }
-    }
-
-    /**
-     * DOM要素存在確認
-     */
-    async _verifyDOMElements() {
-        const playerHand = document.getElementById('player-hand');
-        const cpuHand = document.getElementById('cpu-hand');
-        
-        if (!playerHand || !cpuHand) {
-            throw new Error('Hand elements not found');
-        }
-        
-        console.log('🔍 DOM verification:');
-        console.log(`  Player hand children: ${playerHand.children.length}`);
-        console.log(`  CPU hand children: ${cpuHand.children.length}`);
-        
-        // 要素が空の場合は少し待ってから再確認
-        if (playerHand.children.length === 0 || cpuHand.children.length === 0) {
-            console.log('⏳ Waiting for DOM elements to populate...');
-            await new Promise(resolve => setTimeout(resolve, 100));
-            
-            console.log('🔍 DOM re-verification:');
-            console.log(`  Player hand children: ${playerHand.children.length}`);
-            console.log(`  CPU hand children: ${cpuHand.children.length}`);
-        }
-    }
-
-    /**
-     * 初期手札ドローアニメーション
-     */
-    async _animateInitialHandDraw() {
-        const playerHand = document.getElementById('player-hand');
-        const cpuHand = document.getElementById('cpu-hand');
-
-        const promises = [];
-
-        if (playerHand) {
-            // Select actual card elements inside the hand (skip inner wrapper)
-            const playerCards = Array.from(playerHand.querySelectorAll('.relative'));
-            console.log(`🎴 Player hand has ${playerCards.length} card elements`);
-            
-            // 各カード要素の詳細を確認
-            playerCards.forEach((card, index) => {
-                const img = card.querySelector('img');
-                console.log(`  Player card ${index + 1}: img src = ${img ? img.src : 'no img'}, opacity = ${card.style.opacity}`);
-            });
-            
-            if (playerCards.length > 0) {
-                promises.push(animationManager.animateInitialPlayerHandDeal(playerCards, 200));
-            }
-        }
-
-        if (cpuHand) {
-            const cpuCards = Array.from(cpuHand.querySelectorAll('.relative'));
-            console.log(`🎴 CPU hand has ${cpuCards.length} card elements`);
-            
-            // 各カード要素の詳細を確認
-            cpuCards.forEach((card, index) => {
-                const img = card.querySelector('img');
-                console.log(`  CPU card ${index + 1}: img src = ${img ? img.src : 'no img'}, opacity = ${card.style.opacity}`);
-            });
-            
-            if (cpuCards.length > 0) {
-                promises.push(animationManager.animateInitialHandDeal(cpuCards, 200));
-            }
-        }
-
-        await Promise.all(promises);
-    }
-
-    /**
-     * サイドカード配置アニメーション
-     */
-    async _animatePrizeCardSetup() {
-        // 実際にカード要素が入っているスロットの子要素を取得
-        const playerPrizeSlots = document.querySelectorAll('.player-self .side-left .card-slot');
-        const cpuPrizeSlots = document.querySelectorAll('.opponent-board .side-right .card-slot');
-
-        const prizeCards = [];
-        
-        // プレイヤーのサイドカード要素を収集
-        playerPrizeSlots.forEach((slot, index) => {
-            const cardElement = slot.querySelector('.relative'); // カード要素
-            if (cardElement) {
-                prizeCards.push(cardElement);
-                console.log(`📋 Found player prize card ${index + 1}`);
-            }
-        });
-        
-        // CPUのサイドカード要素を収集
-        cpuPrizeSlots.forEach((slot, index) => {
-            const cardElement = slot.querySelector('.relative'); // カード要素
-            if (cardElement) {
-                prizeCards.push(cardElement);
-                console.log(`📋 Found CPU prize card ${index + 1}`);
-            }
-        });
-
-        console.log(`🏆 Animating ${prizeCards.length} prize card elements`);
-        
-        if (prizeCards.length > 0) {
-            await animationManager.animatePrizeDeal(prizeCards, 150);
-        } else {
-            console.warn('⚠️ No prize card elements found for animation');
-        }
     }
 
     // ==================== アニメーション関連メソッド ====================

--- a/js/setup-manager.js
+++ b/js/setup-manager.js
@@ -4,7 +4,6 @@
  * 初期ポケモン選択、マリガン、サイドカード配置などを管理
  */
 
-import { animationManager } from './animations.js';
 import { GAME_PHASES } from './phase-manager.js';
 import { cloneGameState, addLogEntry } from './state.js';
 
@@ -22,18 +21,15 @@ export class SetupManager {
    * @param {object} state - ゲーム状態
    * @returns {object} 更新されたゲーム状態
    */
-  async initializeGame(state) {
+  initializeGame(state) {
     console.log('🎮 Starting game initialization...');
     let newState = cloneGameState(state);
 
-    // 1. デッキシャッフルアニメーション
-    await this.animateDeckShuffle();
+    // 1. 初期手札をドロー（7枚）
+    newState = this.drawInitialHands(newState);
 
-    // 2. 初期手札をドロー（7枚）
-    newState = await this.drawInitialHands(newState);
-
-    // 3. マリガンチェックと処理
-    newState = await this.handleMulligans(newState);
+    // 2. マリガンチェックと処理
+    newState = this.handleMulligans(newState);
 
     // 4. 初期ポケモン選択フェーズに移行（サイドカードは後で配布）
     newState.phase = GAME_PHASES.INITIAL_POKEMON_SELECTION;
@@ -49,47 +45,9 @@ export class SetupManager {
   }
 
   /**
-   * デッキシャッフルアニメーション
-   */
-  async animateDeckShuffle() {
-    console.log('🔀 Animating deck shuffle...');
-    
-    const playerDeck = document.querySelector('.player-self .deck-container');
-    const cpuDeck = document.querySelector('.opponent-board .deck-container');
-    
-    if (playerDeck && cpuDeck) {
-      // シャッフルアニメーションを同時実行
-      await Promise.all([
-        this.shuffleDeckAnimation(playerDeck),
-        this.shuffleDeckAnimation(cpuDeck)
-      ]);
-    }
-  }
-
-  /**
-   * 単一デッキのシャッフルアニメーション
-   */
-  async shuffleDeckAnimation(deckElement) {
-    return new Promise(resolve => {
-      // シャッフルエフェクト（3回震わせる）
-      let shakeCount = 0;
-      const shakeInterval = setInterval(() => {
-        deckElement.style.transform = `translateX(${Math.random() * 6 - 3}px) translateY(${Math.random() * 6 - 3}px)`;
-        shakeCount++;
-
-        if (shakeCount >= 6) {
-          clearInterval(shakeInterval);
-          deckElement.style.transform = '';
-          resolve();
-        }
-      }, 100);
-    });
-  }
-
-  /**
    * 初期手札ドロー（7枚ずつ）
    */
-  async drawInitialHands(state) {
+  drawInitialHands(state) {
     console.log('🎴 Drawing initial hands...');
     let newState = cloneGameState(state);
 
@@ -124,38 +82,13 @@ export class SetupManager {
       console.log(`  - ${pokemon.name_ja}`);
     });
     
-    // Note: アニメーションはGame.jsでview.render()の後に呼ばれる
-    // ここでは状態の更新のみを行い、アニメーションは別途実行する
-
     return newState;
-  }
-
-  /**
-   * 初期ドローアニメーション
-   */
-  async animateInitialDraw() {
-    const playerHand = document.getElementById('player-hand');
-    const cpuHand = document.getElementById('cpu-hand');
-
-    if (playerHand) {
-      const playerCards = Array.from(playerHand.querySelectorAll('.relative'));
-      if (playerCards.length > 0) {
-        await animationManager.animateInitialPlayerHandDeal(playerCards, 200);
-      }
-    }
-
-    if (cpuHand) {
-      const cpuCards = Array.from(cpuHand.querySelectorAll('.relative'));
-      if (cpuCards.length > 0) {
-        await animationManager.animateInitialHandDeal(cpuCards, 200);
-      }
-    }
   }
 
   /**
    * マリガンチェックと処理
    */
-  async handleMulligans(state) {
+  handleMulligans(state) {
     console.log('🔄 Checking for mulligans...');
     let newState = cloneGameState(state);
 
@@ -192,15 +125,15 @@ export class SetupManager {
         // マリガン処理
         if (playerNeedsMultigan) {
           console.log('🔄 Performing player mulligan...');
-          newState = await this.performMulligan(newState, 'player');
+          newState = this.performMulligan(newState, 'player');
         }
         if (cpuNeedsMultigan) {
           console.log('🔄 Performing CPU mulligan...');
-          newState = await this.performMulligan(newState, 'cpu');
+          newState = this.performMulligan(newState, 'cpu');
         }
 
         // 再帰的にマリガンチェック
-        return await this.handleMulligans(newState);
+        return this.handleMulligans(newState);
       } else {
         console.warn('⚠️ Maximum mulligans exceeded, proceeding with current hands');
         newState = addLogEntry(newState, {
@@ -227,7 +160,7 @@ export class SetupManager {
   /**
    * マリガン処理
    */
-  async performMulligan(state, playerId) {
+  performMulligan(state, playerId) {
     console.log(`🔄 Performing mulligan for ${playerId}`);
     let newState = cloneGameState(state);
     const playerState = newState.players[playerId];
@@ -235,7 +168,7 @@ export class SetupManager {
     // 手札をデッキに戻してシャッフル
     playerState.deck.push(...playerState.hand);
     playerState.hand = [];
-    
+
     // デッキをシャッフル
     this.shuffleArray(playerState.deck);
 
@@ -247,34 +180,13 @@ export class SetupManager {
       }
     }
 
-    // マリガンアニメーション
-    await this.animateMulligan(playerId);
-
     return newState;
-  }
-
-  /**
-   * マリガンアニメーション
-   */
-  async animateMulligan(playerId) {
-    const handElement = playerId === 'player' 
-      ? document.getElementById('player-hand')
-      : document.getElementById('cpu-hand');
-
-    if (handElement) {
-      // コンテナの不透明度は触らない（バグ原因のため）
-      // 新しい手札の入場のみをアニメーション
-      const cards = Array.from(handElement.querySelectorAll('.relative'));
-      if (cards.length > 0) {
-        await animationManager.animateHandEntry(cards);
-      }
-    }
   }
 
   /**
    * サイドカード配置
    */
-  async setupPrizeCards(state) {
+  setupPrizeCards(state) {
     console.log('🏆 Setting up prize cards...');
     let newState = cloneGameState(state);
 
@@ -301,23 +213,9 @@ export class SetupManager {
   }
 
   /**
-   * サイドカード配置アニメーション
-   */
-  async animatePrizeCardSetup() {
-    const playerPrizes = document.querySelectorAll('.player-self .side-left .card-slot');
-    const cpuPrizes = document.querySelectorAll('.opponent-board .side-right .card-slot');
-
-    const allPrizes = [...Array.from(playerPrizes), ...Array.from(cpuPrizes)];
-    
-    if (allPrizes.length > 0) {
-      await animationManager.animatePrizeDeal(allPrizes, 150);
-    }
-  }
-
-  /**
    * 初期ポケモン選択の処理
    */
-  async handlePokemonSelection(state, playerId, cardId, targetZone, targetIndex = 0) {
+  handlePokemonSelection(state, playerId, cardId, targetZone, targetIndex = 0) {
     console.log(`🎯 Pokemon selection: ${playerId} places ${cardId} in ${targetZone}`);
     console.log(`📋 Before selection - ${playerId} hand:`, state.players[playerId].hand.length, 'cards');
     
@@ -399,7 +297,7 @@ export class SetupManager {
     // プレイヤーが最初のポケモンを配置した時、CPUも同期して配置
     if (playerId === 'player' && !newState.players.cpu.active) {
       console.log('🔄 Triggering CPU pokemon setup...');
-      newState = await this.setupCpuInitialPokemon(newState);
+      newState = this.setupCpuInitialPokemon(newState);
     }
     
     return newState;
@@ -408,7 +306,7 @@ export class SetupManager {
   /**
    * CPU用の自動初期ポケモン配置
    */
-  async setupCpuInitialPokemon(state) {
+  setupCpuInitialPokemon(state) {
     console.log('🤖 Setting up CPU initial Pokemon...');
     let newState = cloneGameState(state);
     const cpuState = newState.players.cpu;
@@ -451,30 +349,7 @@ export class SetupManager {
       message: `CPUが初期ポケモンを配置しました（バトル場: ${cpuState.active.name_ja}, ベンチ: ${benchCount}体）`
     });
 
-    // CPU配置アニメーション
-    await this.animateCpuPokemonPlacement();
-
     return newState;
-  }
-
-  /**
-   * CPU配置アニメーション
-   */
-  async animateCpuPokemonPlacement() {
-    const cpuActive = document.querySelector('.opponent-board .active-top');
-    const cpuBench = document.querySelectorAll('.opponent-board .top-bench-1, .opponent-board .top-bench-2, .opponent-board .top-bench-3, .opponent-board .top-bench-4, .opponent-board .top-bench-5');
-
-    const elements = [cpuActive, ...Array.from(cpuBench)];
-    
-    for (const element of elements) {
-      if (element && element.children.length > 0) {
-        await animationManager.animatePlayCard(
-          element.children[0],
-          { x: element.offsetLeft, y: element.offsetTop - 100 },
-          { x: element.offsetLeft, y: element.offsetTop }
-        );
-      }
-    }
   }
 
   /**
@@ -490,7 +365,7 @@ export class SetupManager {
   /**
    * セットアップ確定処理
    */
-  async confirmSetup(state) {
+  confirmSetup(state) {
     console.log('✅ Confirming setup...');
     let newState = cloneGameState(state);
 
@@ -515,7 +390,7 @@ export class SetupManager {
     // CPUの初期ポケモンが未配置の場合は自動配置
     if (!newState.players.cpu.active) {
       console.log('🤖 Setting up CPU Pokemon automatically...');
-      newState = await this.setupCpuInitialPokemon(newState);
+    newState = this.setupCpuInitialPokemon(newState);
     }
 
     // 両プレイヤーがたねポケモンを持っているか最終確認
@@ -562,31 +437,31 @@ export class SetupManager {
   /**
    * ポケモン配置確定後のサイドカード配布処理
    */
-  async confirmPokemonSetupAndProceedToPrizes(state) {
+  confirmPokemonSetupAndProceedToPrizes(state) {
     console.log('✅ Pokemon setup confirmed, proceeding to prize cards...');
     let newState = cloneGameState(state);
-    
+
     // フェーズをサイドカード配布に変更
     newState.phase = GAME_PHASES.PRIZE_CARD_SETUP;
-    
+
     // サイドカード配布
-    newState = await this.setupPrizeCards(newState);
-    
+    newState = this.setupPrizeCards(newState);
+
     // ゲーム開始準備完了フェーズに移行
     newState.phase = GAME_PHASES.GAME_START_READY;
-    
+
     newState = addLogEntry(newState, {
       type: 'prize_setup_complete',
       message: 'サイドカードが配布されました。ゲーム開始の準備が整いました！'
     });
-    
+
     return newState;
   }
 
   /**
    * ゲーム開始時の表向き公開処理
    */
-  async startGameRevealCards(state) {
+  startGameRevealCards(state) {
     console.log('🎬 Starting game with card reveal...');
     let newState = cloneGameState(state);
     


### PR DESCRIPTION
## Summary
- Simplify game setup by removing deck shuffle, mulligan, and prize animations
- Convert setup manager methods to synchronous flow and remove animation scheduling
- Keep essential card placement and draw animations intact

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1e08dbc832ba644627da14208c7