### PR TITLE
feat: auto draw to show action buttons

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -808,9 +808,10 @@ export class Game {
         newState.canRetreat = true;
         newState.canPlaySupporter = true;
 
-        // 4. ドローフェーズに移行
-        newState.phase = GAME_PHASES.PLAYER_DRAW;
-        newState.prompt.message = '山札をクリックしてカードを引いてください。';
+        // 4. プレイヤーの初手ドローを自動で実行しメインフェーズへ
+        newState = await this.turnManager.handlePlayerDraw(newState);
+        newState.phase = GAME_PHASES.PLAYER_MAIN;
+        newState.prompt.message = 'あなたのターンです。アクションを選択してください。';
 
         this._updateState(newState);
 


### PR DESCRIPTION
## Summary
- auto draw a card at game start and enter main phase so player actions (retreat, attack, end turn) are visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a59a265828832b90930c8882950f7e