### PR TITLE
Make action buttons visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -888,13 +888,13 @@
 
             <!-- Player Action Buttons -->
             <div id="player-action-buttons" class="flex justify-center gap-4">
-                <button id="retreat-button" class="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white font-bold rounded-lg shadow-lg text-sm hidden">
+                <button id="retreat-button" class="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white font-bold rounded-lg shadow-lg text-sm">
                     にげる
                 </button>
-                <button id="attack-button" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-bold rounded-lg shadow-lg text-sm hidden">
+                <button id="attack-button" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-bold rounded-lg shadow-lg text-sm">
                     攻撃
                 </button>
-                <button id="end-turn-button" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg shadow-lg text-sm hidden">
+                <button id="end-turn-button" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg shadow-lg text-sm">
                     ターン終了
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- Remove `hidden` class from Retreat, Attack, and End Turn buttons so they're displayed in the game status panel

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a59bc28b80832bb0e9764cadb9befa