### PR TITLE
fix: preserve static buttons and improve event binding

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -51,10 +51,8 @@ export class Game {
             this.view.bindCardClick(this._handleCardClick.bind(this));
             this.view.setConfirmSetupButtonHandler(this._handleConfirmSetup.bind(this)); // Bind confirm button
 
-            // Bind action buttons
-            this.view.retreatButton.onclick = this._handleRetreat.bind(this);
-            this.view.attackButton.onclick = this._handleAttack.bind(this);
-            this.view.endTurnButton.onclick = this._handleEndTurn.bind(this); // Bind end turn button
+            // Bind action buttons after ensuring DOM is ready
+            this.bindActionButtons();
 
             // Render the initial board state immediately after state creation
             
@@ -95,6 +93,56 @@ export class Game {
         // Then control UI elements based on phase
         this._updateUI();
     } // End of _updateState
+
+    /**
+     * アクションボタンのイベントハンドラーを遅延バインドする
+     */
+    bindActionButtons() {
+        // より確実な方法：DOM要素の存在を確認してからバインド
+        const bindWhenReady = () => {
+            const retreatButton = document.getElementById('retreat-button');
+            const attackButton = document.getElementById('attack-button');
+            const endTurnButton = document.getElementById('end-turn-button');
+
+            let boundCount = 0;
+
+            if (retreatButton) {
+                retreatButton.onclick = this._handleRetreat.bind(this);
+                console.log('✅ Retreat button event handler bound');
+                boundCount++;
+            }
+
+            if (attackButton) {
+                attackButton.onclick = this._handleAttack.bind(this);
+                console.log('✅ Attack button event handler bound');
+                boundCount++;
+            }
+
+            if (endTurnButton) {
+                endTurnButton.onclick = this._handleEndTurn.bind(this);
+                console.log('✅ End turn button event handler bound');
+                boundCount++;
+            }
+
+            if (boundCount === 3) {
+                console.log('🎯 All action button event handlers successfully bound');
+                return true;
+            } else {
+                console.warn(`⚠️ Only ${boundCount}/3 buttons found and bound`);
+                return false;
+            }
+        };
+
+        // 即座に試行
+        if (!bindWhenReady()) {
+            // 失敗した場合は少し待ってから再試行
+            setTimeout(() => {
+                if (!bindWhenReady()) {
+                    console.error('❌ Failed to bind some action buttons after retry');
+                }
+            }, 100);
+        }
+    }
 
     async _handleCardClick(dataset) {
         const { owner, zone, cardId, index } = dataset;

--- a/js/view.js
+++ b/js/view.js
@@ -934,7 +934,7 @@ export class View {
             const button = document.createElement('button');
             button.textContent = action.text;
             // Tailwind CSS クラスを適用
-            button.className = action.className || 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg shadow-lg text-sm';
+            button.className = (action.className || 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg shadow-lg text-sm') + ' pokemon-action-button';
             button.addEventListener('click', () => {
                 action.callback();
                 this.clearInteractiveButtons(); // アクション実行後にボタンをクリア
@@ -942,18 +942,30 @@ export class View {
             });
             this.playerActionButtonsContainer.appendChild(button);
         });
-        
-        // アクションボタンコンテナを表示
+
+        // 動的ボタンが追加されたのでコンテナを表示
         this.playerActionButtonsContainer.classList.remove('hidden');
+        console.log(`🎯 Added ${actions.length} dynamic action buttons`);
     }
 
     /**
      * 動的に追加されたインタラクティブボタンをクリア
+     * 静的HTML定義のボタンは保持する
      */
     clearInteractiveButtons() {
         if (this.playerActionButtonsContainer) {
-            this.playerActionButtonsContainer.innerHTML = '';
-            this.playerActionButtonsContainer.classList.add('hidden'); // ボタンがなくなったらコンテナも非表示
+            // 動的に作成されたボタン（pokemon-action-buttonクラスを持つもの）のみを削除
+            const dynamicButtons = this.playerActionButtonsContainer.querySelectorAll('.pokemon-action-button');
+            dynamicButtons.forEach(button => button.remove());
+
+            // 静的ボタンが残っているかチェック
+            const staticButtons = this.playerActionButtonsContainer.querySelectorAll('button:not(.pokemon-action-button)');
+            if (staticButtons.length === 0) {
+                // 静的ボタンも動的ボタンもない場合のみコンテナを非表示
+                this.playerActionButtonsContainer.classList.add('hidden');
+            }
+
+            console.log(`🧹 Cleared ${dynamicButtons.length} dynamic buttons, ${staticButtons.length} static buttons remain`);
         }
     }
 
@@ -1019,18 +1031,46 @@ export class View {
             this.endTurnButton,
             this.confirmSetupButton
         ];
+
+        // 全ての静的ボタンをまず隠す
         allButtons.forEach(button => {
             if (button) {
-                button.classList.add('hidden'); // Hide all first
+                button.classList.add('hidden');
             }
         });
 
+        let visibleButtonCount = 0;
         buttonsToShow.forEach(buttonId => {
-            const button = document.getElementById(buttonId);
+            // 直接IDから取得する代わりに、キャッシュされたボタンを使用
+            let button = null;
+            switch (buttonId) {
+                case 'retreat-button':
+                    button = this.retreatButton;
+                    break;
+                case 'attack-button':
+                    button = this.attackButton;
+                    break;
+                case 'end-turn-button':
+                    button = this.endTurnButton;
+                    break;
+                case 'confirm-setup-button':
+                    button = this.confirmSetupButton;
+                    break;
+            }
             if (button) {
+                console.log(`🎯 Showing button: ${buttonId}`);
                 button.classList.remove('hidden');
+                visibleButtonCount++;
+            } else {
+                console.error(`❌ Button not found: ${buttonId}`);
             }
         });
+
+        // 静的ボタンが表示される場合は、コンテナも表示
+        if (visibleButtonCount > 0) {
+            this.playerActionButtonsContainer.classList.remove('hidden');
+            console.log(`✅ Showing action button container with ${visibleButtonCount} static buttons`);
+        }
     }
 
     hideActionButtons() {
@@ -1040,11 +1080,23 @@ export class View {
             this.endTurnButton,
             this.confirmSetupButton
         ];
+
         allButtons.forEach(button => {
             if (button) {
                 button.classList.add('hidden');
             }
         });
+
+        // 全ての静的ボタンが隠された後、動的ボタンがあるかチェック
+        if (this.playerActionButtonsContainer) {
+            const dynamicButtons = this.playerActionButtonsContainer.querySelectorAll('.pokemon-action-button');
+            if (dynamicButtons.length === 0) {
+                // 動的ボタンもない場合はコンテナを隠す
+                this.playerActionButtonsContainer.classList.add('hidden');
+                console.log('🙈 Hiding action button container - no buttons visible');
+            }
+        }
+
         this.hideInitialPokemonSelectionUI();
     }
 
@@ -1950,7 +2002,7 @@ export class View {
             const button = document.createElement('button');
             button.textContent = action.text;
             // Tailwind CSS クラスを適用
-            button.className = action.className || 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg shadow-lg text-sm';
+            button.className = (action.className || 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-lg shadow-lg text-sm') + ' pokemon-action-button';
             button.addEventListener('click', () => {
                 action.callback();
                 this.clearInteractiveButtons(); // アクション実行後にボタンをクリア
@@ -1958,18 +2010,30 @@ export class View {
             });
             this.playerActionButtonsContainer.appendChild(button);
         });
-        
-        // アクションボタンコンテナを表示
+
+        // 動的ボタンが追加されたのでコンテナを表示
         this.playerActionButtonsContainer.classList.remove('hidden');
+        console.log(`🎯 Added ${actions.length} dynamic action buttons`);
     }
 
     /**
      * 動的に追加されたインタラクティブボタンをクリア
+     * 静的HTML定義のボタンは保持する
      */
     clearInteractiveButtons() {
         if (this.playerActionButtonsContainer) {
-            this.playerActionButtonsContainer.innerHTML = '';
-            this.playerActionButtonsContainer.classList.add('hidden'); // ボタンがなくなったらコンテナも非表示
+            // 動的に作成されたボタン（pokemon-action-buttonクラスを持つもの）のみを削除
+            const dynamicButtons = this.playerActionButtonsContainer.querySelectorAll('.pokemon-action-button');
+            dynamicButtons.forEach(button => button.remove());
+
+            // 静的ボタンが残っているかチェック
+            const staticButtons = this.playerActionButtonsContainer.querySelectorAll('button:not(.pokemon-action-button)');
+            if (staticButtons.length === 0) {
+                // 静的ボタンも動的ボタンもない場合のみコンテナを非表示
+                this.playerActionButtonsContainer.classList.add('hidden');
+            }
+
+            console.log(`🧹 Cleared ${dynamicButtons.length} dynamic buttons, ${staticButtons.length} static buttons remain`);
         }
     }
 
@@ -2055,18 +2119,46 @@ export class View {
             this.endTurnButton,
             this.confirmSetupButton
         ];
+
+        // 全ての静的ボタンをまず隠す
         allButtons.forEach(button => {
             if (button) {
-                button.classList.add('hidden'); // Hide all first
+                button.classList.add('hidden');
             }
         });
 
+        let visibleButtonCount = 0;
         buttonsToShow.forEach(buttonId => {
-            const button = document.getElementById(buttonId);
+            // 直接IDから取得する代わりに、キャッシュされたボタンを使用
+            let button = null;
+            switch (buttonId) {
+                case 'retreat-button':
+                    button = this.retreatButton;
+                    break;
+                case 'attack-button':
+                    button = this.attackButton;
+                    break;
+                case 'end-turn-button':
+                    button = this.endTurnButton;
+                    break;
+                case 'confirm-setup-button':
+                    button = this.confirmSetupButton;
+                    break;
+            }
             if (button) {
+                console.log(`🎯 Showing button: ${buttonId}`);
                 button.classList.remove('hidden');
+                visibleButtonCount++;
+            } else {
+                console.error(`❌ Button not found: ${buttonId}`);
             }
         });
+
+        // 静的ボタンが表示される場合は、コンテナも表示
+        if (visibleButtonCount > 0) {
+            this.playerActionButtonsContainer.classList.remove('hidden');
+            console.log(`✅ Showing action button container with ${visibleButtonCount} static buttons`);
+        }
     }
 
     hideActionButtons() {
@@ -2076,11 +2168,23 @@ export class View {
             this.endTurnButton,
             this.confirmSetupButton
         ];
+
         allButtons.forEach(button => {
             if (button) {
                 button.classList.add('hidden');
             }
         });
+
+        // 全ての静的ボタンが隠された後、動的ボタンがあるかチェック
+        if (this.playerActionButtonsContainer) {
+            const dynamicButtons = this.playerActionButtonsContainer.querySelectorAll('.pokemon-action-button');
+            if (dynamicButtons.length === 0) {
+                // 動的ボタンもない場合はコンテナを隠す
+                this.playerActionButtonsContainer.classList.add('hidden');
+                console.log('🙈 Hiding action button container - no buttons visible');
+            }
+        }
+
         this.hideInitialPokemonSelectionUI();
     }
 


### PR DESCRIPTION
## Summary
- Preserve static action buttons when clearing dynamic ones and hide container only when empty
- Show action button container when buttons are visible and hide after all are cleared
- Bind action button handlers only when DOM elements exist, retrying if necessary

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a3291150832bab1e3b5408051a90