### PR TITLE
refactor: centralize z-index management

### DIFF
--- a/js/animations/flow.js
+++ b/js/animations/flow.js
@@ -9,6 +9,7 @@
 
 import { animate } from '../animation-manager.js';
 import { normalizePlayerId, findZoneElement, findBenchSlot } from '../dom-utils.js';
+import { ZIndexManager } from '../z-index-constants.js';
 
 function resolveHandCardElement(playerId, runtimeOrMasterId) {
   const pid = normalizePlayerId(playerId);
@@ -120,8 +121,8 @@ async function cloneMoveFromRectToTarget(initialRect, targetElement, duration = 
   clone.style.boxShadow = '0 8px 25px rgba(0,0,0,0.3)';
   clone.style.transform = 'scale(0.9)';
   clone.style.transition = 'none';
-  // 高いz-indexで常に前面に表示（CSS変数に依存しない）
-  clone.style.zIndex = '9999';
+  // 中央管理のZIndexManagerで最前面に表示
+  ZIndexManager.setAnimating(clone);
   document.body.appendChild(clone);
 
   // 強制reflow

--- a/js/game.js
+++ b/js/game.js
@@ -11,6 +11,7 @@ import { turnManager } from './turn-manager.js';
 import { getCardImagePath, loadCardsFromJSON, getCardMasterList } from './data-manager.js';
 import { addLogEntry } from './state.js';
 import { modalManager } from './modal-manager.js';
+import { ZIndexManager } from './z-index-constants.js';
 import { memoryManager } from './memory-manager.js';
 import { actionHUDManager } from './action-hud-manager.js';
 
@@ -1903,7 +1904,6 @@ export class Game {
         const resultModal = document.createElement('div');
         resultModal.id = 'game-result-modal';
         resultModal.className = 'fixed inset-0 flex items-center justify-center game-result-overlay';
-        resultModal.style.zIndex = 'var(--z-modals)';
         
         const modalContent = `
             <div class="game-result-container ${isVictory ? 'victory-result' : 'defeat-result'}">
@@ -1973,6 +1973,7 @@ export class Game {
         
         resultModal.innerHTML = modalContent;
         document.body.appendChild(resultModal);
+        ZIndexManager.apply(resultModal, 'MODALS');
         
         // アニメーション開始
         requestAnimationFrame(() => {
@@ -2063,7 +2064,7 @@ export class Game {
                 card.style.boxShadow = '0 0 30px rgba(252, 211, 77, 0.8), 0 0 60px rgba(252, 211, 77, 0.4)';
                 card.style.transform = 'scale(1.1)';
                 card.style.transition = 'all 0.8s cubic-bezier(0.34, 1.56, 0.64, 1)';
-                card.style.zIndex = 'var(--z-animations)';
+                ZIndexManager.apply(card, 'ANIMATIONS');
             }, index * 150);
         });
 
@@ -2077,7 +2078,7 @@ export class Game {
             card.classList.remove('victory-celebration');
             card.style.transform = '';
             card.style.boxShadow = '';
-            card.style.zIndex = '';
+            ZIndexManager.reset(card);
         });
         
         if (gameBoard) {
@@ -2115,7 +2116,7 @@ export class Game {
                 card.style.boxShadow = '0 0 25px rgba(239, 68, 68, 0.6), 0 0 50px rgba(239, 68, 68, 0.3)';
                 card.style.transform = 'scale(1.08)';
                 card.style.transition = 'all 0.8s cubic-bezier(0.34, 1.56, 0.64, 1)';
-                card.style.zIndex = 'var(--z-animations)';
+                ZIndexManager.apply(card, 'ANIMATIONS');
             }, index * 120);
         });
 
@@ -2128,7 +2129,7 @@ export class Game {
         cpuCards.forEach(card => {
             card.style.transform = '';
             card.style.boxShadow = '';
-            card.style.zIndex = '';
+            ZIndexManager.reset(card);
         });
     }
 
@@ -2146,7 +2147,7 @@ export class Game {
             particle.style.left = Math.random() * 100 + '%';
             particle.style.top = Math.random() * 100 + '%';
             particle.style.fontSize = (0.8 + Math.random() * 1.2) + 'rem';
-            particle.style.zIndex = 'var(--z-animations)';
+            ZIndexManager.apply(particle, 'ANIMATIONS');
             particle.style.pointerEvents = 'none';
             particle.innerHTML = ['⭐', '✨', '🎊', '🎉', '💫', '🌟'][Math.floor(Math.random() * 6)];
             particle.style.animation = `boardVictoryFloat ${2 + Math.random() * 3}s ease-out ${Math.random() * 1}s forwards`;
@@ -2177,7 +2178,7 @@ export class Game {
             particle.style.height = '15px';
             particle.style.background = 'rgba(156, 163, 175, 0.6)';
             particle.style.borderRadius = '2px';
-            particle.style.zIndex = 'var(--z-animations)';
+            ZIndexManager.apply(particle, 'ANIMATIONS');
             particle.style.pointerEvents = 'none';
             particle.style.animation = `boardDefeatFall ${3 + Math.random() * 2}s linear ${Math.random() * 0.5}s forwards`;
 

--- a/js/modal-manager.js
+++ b/js/modal-manager.js
@@ -5,8 +5,7 @@
  * 4つのモーダルタイプを管理：中央モーダル、通知トースト、アクションHUD、状況パネル
  */
 
-import { animationManager } from './animation-manager.js';
-import { Z_INDEX, Z_CSS_VARS } from './z-index-constants.js';
+import { ZIndexManager } from './z-index-constants.js';
 import { getCardImagePath } from './data-manager.js';
 
 const noop = () => {};
@@ -24,17 +23,17 @@ export const MODAL_TYPES = {
 
 /**
  * モーダル優先度（Z-Index管理用）
- * CSS変数と統合された定数値
+ * ZIndexManagerに渡すキーを定義
  */
 export const MODAL_PRIORITY = {
-    BACKGROUND: Z_INDEX.BOARD,        // --z-board (ゲームボード)
-    CARDS: Z_INDEX.SELECTED,          // --z-selected (カード・手札選択状態)
-    HUD: Z_INDEX.HUD_BASE,            // --z-hud-base (HUD要素)
-    ACTION_HUD: Z_INDEX.FLOATING_HUD, // --z-floating-hud (廃止予定)
-    FLOATING_HUD: Z_INDEX.FLOATING_HUD, // --z-floating-hud (フローティングアクションHUD)
-    TOAST: Z_INDEX.TOAST,             // --z-toast (通知)
-    CENTRAL: Z_INDEX.MODALS,          // --z-modals (中央モーダル)
-    CRITICAL: Z_INDEX.CRITICAL        // --z-critical (致命的エラー)
+    BACKGROUND: 'BOARD',
+    CARDS: 'SELECTED',
+    HUD: 'HUD_BASE',
+    ACTION_HUD: 'FLOATING_HUD',
+    FLOATING_HUD: 'FLOATING_HUD',
+    TOAST: 'TOAST',
+    CENTRAL: 'MODALS',
+    CRITICAL: 'CRITICAL'
 };
 
 /**
@@ -86,15 +85,15 @@ export class ModalManager {
         const modal = document.createElement('div');
         modal.id = 'central-modal';
         modal.className = 'hidden fixed inset-0 central-modal flex items-center justify-center';
-        modal.style.zIndex = MODAL_PRIORITY.CENTRAL;
-        
+
         const content = document.createElement('div');
         // widen modal for rich card details layout (image + info)
         content.className = 'central-modal-content rounded-lg shadow-2xl p-6 w-fit max-w-5xl m-4 transform transition-all duration-300 ease-out scale-95 opacity-0';
-        
+
         modal.appendChild(content);
         document.body.appendChild(modal);
-        
+        ZIndexManager.apply(modal, MODAL_PRIORITY.CENTRAL);
+
         return modal;
     }
 
@@ -112,13 +111,13 @@ export class ModalManager {
         container.style.bottom = '180px'; // 手札エリア（bottom: 10px + 約170px高さ）の上
         container.style.left = '50%'; // 水平中央
         container.style.transform = 'translateX(-50%)'; // 中央揃え
-        container.style.zIndex = MODAL_PRIORITY.TOAST; // 95 - 中央モーダル(100)より背面
         container.style.willChange = 'auto';
         container.style.perspective = 'none';
         container.style.maxWidth = '400px'; // 最大幅制限
         container.style.width = 'fit-content';
-        
+
         document.body.appendChild(container);
+        ZIndexManager.apply(container, MODAL_PRIORITY.TOAST);
         return container;
     }
 
@@ -129,9 +128,9 @@ export class ModalManager {
         const hud = document.createElement('div');
         hud.id = 'action-hud';
         hud.className = 'hidden fixed pointer-events-none';
-        hud.style.zIndex = MODAL_PRIORITY.ACTION_HUD;
-        
+
         document.body.appendChild(hud);
+        ZIndexManager.apply(hud, MODAL_PRIORITY.ACTION_HUD);
         return hud;
     }
 
@@ -214,7 +213,7 @@ export class ModalManager {
         }
 
         // 表示
-        this.centralModal.style.zIndex = priority;
+        ZIndexManager.apply(this.centralModal, priority);
         this.centralModal.classList.remove('hidden');
         this.centralModal.style.display = 'flex';
         


### PR DESCRIPTION
## Summary
- centralize modal z-index handling via `ZIndexManager`
- apply managed layers to game animations and particle effects
- replace hardcoded z-indexes in animation flow helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b2e4c18832bb891618b59175cc3