### PR TITLE
fix: centralize z-depth and slider bounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,8 @@
 
         #game-board {
             transform-style: preserve-3d;
-            transform: rotateX(45deg); /* More dramatic tilt for better perspective */
+            /* Allow dynamic Z positioning via CSS variable */
+            transform: translateZ(var(--tz-game-board)) rotateX(45deg); /* More dramatic tilt for better perspective */
             position: relative;
             /* Adjust height to fit between hands and footer */
             height: min(
@@ -2358,7 +2359,8 @@
 
 
     <script>
-        const noop = () => {};
+        // Expose noop globally so modules can reuse it without errors
+        window.noop = () => {};
         document.addEventListener('DOMContentLoaded', async () => {
             const gameBoard = document.getElementById('game-board');
             const bgImage = document.querySelector('.board-bg');
@@ -2556,11 +2558,20 @@
             // Z-Position Slider Control
             const zSlider = document.getElementById('z-slider');
             const zSliderValueDisplay = document.getElementById('z-slider-value');
-            const gameBoard = document.getElementById('game-board'); // Already defined, but good to be explicit
 
             if (zSlider && zSliderValueDisplay && gameBoard) {
+                const rootStyles = getComputedStyle(document.documentElement);
+                const cpuHandZ = parseInt(rootStyles.getPropertyValue('--tz-cpu-hand')) || -60;
+                const playerHandZ = parseInt(rootStyles.getPropertyValue('--tz-player-hand')) || 200;
+
+                // Restrict slider so the board stays between CPU and player hands
+                zSlider.min = cpuHandZ + 1;
+                zSlider.max = playerHandZ - 1;
+
                 // Set initial value display
-                zSliderValueDisplay.textContent = `${zSlider.value}px`;
+                const initialZ = parseInt(rootStyles.getPropertyValue('--tz-game-board')) || zSlider.value;
+                zSlider.value = initialZ;
+                zSliderValueDisplay.textContent = `${initialZ}px`;
 
                 // Update slider value and game board transform on input
                 zSlider.addEventListener('input', () => {
@@ -2601,7 +2612,8 @@
     <script type="module">
         // Modal Manager の初期化
         import { modalManager } from './js/modal-manager.js';
-        
+        const noop = window.noop || (() => {});
+
         // DOM準備完了後にModal Managerを初期化
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', () => {

--- a/js/z-index-constants.js
+++ b/js/z-index-constants.js
@@ -47,11 +47,12 @@ export const Z_INDEX = {
     CRITICAL: 600,         // --z-critical (致命的エラー・アニメーション)
 
     // === 3D Transform Z-Depth (translateZ) ===
-    TZ_PLAYER_HAND: 100,
+    TZ_PLAYER_HAND: 200,
     TZ_CPU_HAND: -60,
     TZ_CARD_SLOT: 1,
     TZ_DAMAGE_COUNTER: 1,
     TZ_CARD_IMAGE_BASE: 0,
+    TZ_GAME_BOARD: 0,
 };
 
 /**
@@ -90,6 +91,7 @@ export const Z_CSS_VARS = {
     TZ_CARD_SLOT: 'var(--tz-card-slot)',
     TZ_DAMAGE_COUNTER: 'var(--tz-damage-counter)',
     TZ_CARD_IMAGE_BASE: 'var(--tz-card-image-base)',
+    TZ_GAME_BOARD: 'var(--tz-game-board)',
 };
 
 /**


### PR DESCRIPTION
## Summary
- manage 3D depth via CSS variables and constants
- expose global noop and remove duplicate gameBoard definition
- limit playmat slider to stay between CPU and player hands

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa671f89cc832bbb310bc29de643a5